### PR TITLE
Make Missile Expansions show up on metal detectors.

### DIFF
--- a/Tiles/ItemTile/MissileExpansionTile.cs
+++ b/Tiles/ItemTile/MissileExpansionTile.cs
@@ -13,6 +13,7 @@ namespace MetroidMod.Tiles.ItemTile
 			name.SetDefault("Missile Expansion");
 			AddMapEntry(new Color(132, 4, 20), name);
 			drop = mod.ItemType("MissileExpansion");
+			Main.tileValue[Type] = 805;
 			dustType = 1;
 			animationFrameHeight = 18;
 		}


### PR DESCRIPTION
- Make Missile Expansions have similar metal detector priority to Life Crystals and Life Fruits
Rebalance if need be.