### PR TITLE
Fix Chozo Ghost priority

### DIFF
--- a/NPCs/Town/ChozoGhost.cs
+++ b/NPCs/Town/ChozoGhost.cs
@@ -31,6 +31,7 @@ namespace MetroidMod.NPCs.Town
 			NPCID.Sets.AttackAverageChance[npc.type] = 30;
 
 			NPCID.Sets.HatOffsetY[npc.type] = 4;
+			WorldGen.prioritizedTownNPC = MWorld.bossesDown.HasFlag(MetroidBossDown.downedTorizo) ? npc.type : WorldGen.prioritizedTownNPC;
 		}
 
 		public override void SetDefaults()


### PR DESCRIPTION
- one line of code again lol
I suppose I should explain how this works. The line of code first evaluates whether the player has killed Torizo yet. Based on whether that is true or not, it will set the prioritized Town NPC to be the Chozo Ghost's ID if true or keep it the same if not.