### PR TITLE
Fix Energy Station effect not being affected by buffs.

### DIFF
--- a/Buffs/EnergyRecharge.cs
+++ b/Buffs/EnergyRecharge.cs
@@ -18,7 +18,7 @@ namespace MetroidMod.Buffs
 		public override void Update(Player player, ref int buffIndex)
 		{
 			MPlayer mp = player.GetModPlayer<MPlayer>();
-			if ((player.statLife >= player.statLifeMax && mp.reserveHearts >= mp.reserveTanks) || player.controlJump || player.controlUseItem)
+			if ((player.statLife >= player.statLifeMax2 && mp.reserveHearts >= mp.reserveTanks) || player.controlJump || player.controlUseItem)
 			{
 				if(soundInstance != null)
 				{
@@ -31,7 +31,7 @@ namespace MetroidMod.Buffs
 			}
 			else
 			{
-				if (player.statLife < player.statLifeMax)
+				if (player.statLife < player.statLifeMax2)
 				{
 					player.statLife++;
 				}


### PR DESCRIPTION
- Changed instances of `player.statLifeMax` to `player.statLifeMax2` in the Energy Recharge buff to account for secondary health.
NOTE: This fix does not work with LuiAFK's unlimited lifeforce potion.