### PR TITLE
Sound Design Rework, Part 1: Missiles

### DIFF
--- a/Content/Items/Weapons/MissileLauncher.cs
+++ b/Content/Items/Weapons/MissileLauncher.cs
@@ -70,7 +70,7 @@ namespace MetroidMod.Content.Items.Weapons
 			Item.knockBack = 5.5f;
 			Item.value = 20000;
 			Item.rare = ItemRarityID.Green;
-			Item.UseSound = Sounds.Items.Weapons.MissileSound;
+			Item.UseSound = Sounds.Items.Weapons.MissileShoot;
 			Item.autoReuse = false;
 			Item.shoot = ModContent.ProjectileType<MissileShot>();
 			Item.shootSpeed = 8f;
@@ -120,7 +120,7 @@ namespace MetroidMod.Content.Items.Weapons
 
 		string shot = "MissileShot";
 		string chargeShot = "DiffusionMissileShot";
-		string shotSound = "MissileSound";
+		string shotSound = "MissileShoot";
 		string chargeShotSound = "SuperMissileSound";
 		string chargeUpSound = "ChargeStartup_Power";
 		string chargeTex = "ChargeLead_PlasmaRed";
@@ -179,7 +179,7 @@ namespace MetroidMod.Content.Items.Weapons
 			useTime = 9;
 			shot = "MissileShot";
 			chargeShot = "";
-			shotSound = "MissileSound";
+			shotSound = "MissileShoot";
 			chargeShotSound = "SuperMissileSound";
 			chargeUpSound = "";
 			chargeTex = "";
@@ -226,22 +226,27 @@ namespace MetroidMod.Content.Items.Weapons
 			if (slot2.type == sm)
 			{
 				shot = "SuperMissileShot";
+				shotSound = "SuperMissileShoot";
 			}
 			else if (slot2.type == ic)
 			{
 				shot = "IceMissileShot";
+				shotSound = "MissileShoot";
 			}
 			else if (slot2.type == icSm)
 			{
 				shot = "IceSuperMissileShot";
+				shotSound = "IceMissileShoot";
 			}
 			else if (slot2.type == st)
 			{
 				shot = "StardustMissileShot";
+				shotSound = "SuperMissileShoot";
 			}
 			else if (slot2.type == ne)
 			{
 				shot = "NebulaMissileShot";
+				shotSound = "SuperMissileShoot";
 			}
 
 			int wb = ModContent.ItemType<WavebusterAddon>();

--- a/Content/Projectiles/missiles/DiffusionMissileShot.cs
+++ b/Content/Projectiles/missiles/DiffusionMissileShot.cs
@@ -66,7 +66,7 @@ namespace MetroidMod.Content.Projectiles.missiles
 			P.position.X = P.position.X - (float)(P.width / 2);
 			P.position.Y = P.position.Y - (float)(P.height / 2);
 
-			SoundEngine.PlaySound(SoundID.Item14,P.position);
+			//SoundEngine.PlaySound(SoundID.Item14,P.position);
 			
 			int dustType = 6;
 			int dustType2 = 30;
@@ -74,6 +74,11 @@ namespace MetroidMod.Content.Projectiles.missiles
 			if(P.Name.Contains("Ice"))
 			{
 				dustType = 135;
+				SoundEngine.PlaySound(Sounds.Items.Weapons.IceMissileExplode,Projectile.position);
+			}
+			else
+			{
+				SoundEngine.PlaySound(Sounds.Items.Weapons.SuperMissileExplode,Projectile.position);
 			}
 			if(P.Name.Contains("Stardust"))
 			{

--- a/Content/Projectiles/missiles/MissileShot.cs
+++ b/Content/Projectiles/missiles/MissileShot.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ModLoader;
+using Terraria.Audio;
 
 namespace MetroidMod.Content.Projectiles.missiles
 {
@@ -80,7 +81,8 @@ namespace MetroidMod.Content.Projectiles.missiles
 			Projectile.position.X = Projectile.position.X - (float)(Projectile.width / 2);
 			Projectile.position.Y = Projectile.position.Y - (float)(Projectile.height / 2);
 
-			Terraria.Audio.SoundEngine.PlaySound(Terraria.ID.SoundID.Item14,Projectile.position);
+			//Terraria.Audio.SoundEngine.PlaySound(Terraria.ID.SoundID.Item14,Projectile.position);
+			SoundEngine.PlaySound(Sounds.Items.Weapons.MissileExplode,Projectile.position);
 			
 			int dustType = 6;
 			if(Projectile.Name.Contains("Ice"))

--- a/Content/Projectiles/missiles/SuperMissileShot.cs
+++ b/Content/Projectiles/missiles/SuperMissileShot.cs
@@ -110,7 +110,7 @@ namespace MetroidMod.Content.Projectiles.missiles
 			P.position.X = P.position.X - (float)(P.width / 2);
 			P.position.Y = P.position.Y - (float)(P.height / 2);
 
-			SoundEngine.PlaySound(SoundID.Item14,P.position);
+			//SoundEngine.PlaySound(SoundID.Item14,P.position);
 			
 			int dustType = 6;
 			int dustType2 = 30;
@@ -118,6 +118,11 @@ namespace MetroidMod.Content.Projectiles.missiles
 			if(P.Name.Contains("Ice"))
 			{
 				dustType = 135;
+				SoundEngine.PlaySound(Sounds.Items.Weapons.IceMissileExplode,Projectile.position);
+			}
+			else
+			{
+				SoundEngine.PlaySound(Sounds.Items.Weapons.SuperMissileExplode,Projectile.position);
 			}
 			if(P.Name.Contains("Stardust"))
 			{

--- a/Sounds.cs
+++ b/Sounds.cs
@@ -78,6 +78,36 @@ namespace MetroidMod
 
 				};
 
+				public static readonly SoundStyle MissileShoot = new($"{nameof(MetroidMod)}/Assets/Sounds/MissileShoot")
+				{
+
+				};
+
+				public static readonly SoundStyle MissileExplode = new($"{nameof(MetroidMod)}/Assets/Sounds/MissileExplode")
+				{
+
+				};
+
+				public static readonly SoundStyle SuperMissileShoot = new($"{nameof(MetroidMod)}/Assets/Sounds/SuperMissileShoot")
+				{
+
+				};
+
+				public static readonly SoundStyle SuperMissileExplode = new($"{nameof(MetroidMod)}/Assets/Sounds/SuperMissileExplode")
+				{
+
+				};
+
+				public static readonly SoundStyle IceMissileShoot = new($"{nameof(MetroidMod)}/Assets/Sounds/IceMissileShoot")
+				{
+
+				};
+
+				public static readonly SoundStyle IceMissileExplode = new($"{nameof(MetroidMod)}/Assets/Sounds/IceMissileExplode")
+				{
+
+				};
+
 				public static readonly SoundStyle ChargeComboActivate = new($"{nameof(MetroidMod)}/Assets/Sounds/ChargeComboActivate")
 				{
 

--- a/description.txt
+++ b/description.txt
@@ -27,6 +27,7 @@ Credits:
 -Some suit addon textures.
 -Expanding the Config.
 -Optimizing the Music files.
+-Missile Sound Rework.
 [Wandering Spider, Klover, MetroidPrime21, Missingno, and Prismatic]
 -Some suit addon textures.
 [VinniSauce]


### PR DESCRIPTION
I noticed that Missiles were lacking in punch, so I gave the Missile Launcher and its respective Projectiles some unique sound effects, rather than a generic shoot sound with a generic explosion sound.

-Missile Shoot sound now varies between what kid of ammunition is used. (Super Missiles, Ice Super Missiles and Diffusion Missiles give it a stronger shoot sound effect, for example.)
-The original "MissileSound" is now used exclusively for Seeker Missile usage.
-Missile Explode sounds also depend on what type of Missile is shot out. Super Missile explosions and above will, again, bear an appropriate explosion sound.

The sounds used are from Metroid Fusion. There will be more variance (and possibly better sounds) when I find the time.