### PR TITLE
Description Revision of the Morph Ball Wall-Jump Option

### DIFF
--- a/Common/Configs/MConfigMain.cs
+++ b/Common/Configs/MConfigMain.cs
@@ -44,7 +44,7 @@ namespace MetroidMod.Common.Configs
 		//[DefaultValue(false)]
 		//internal bool veryBrokenHatchControl;
 
-	[Header("[i:3611] Old movement tech")]
+	[Header("[i:3611] Tech Preservation")]
 
 		[Label("[i:MetroidMod/SpaceJumpAddon] Space Jump doesn't override Rocket Boots")]
 		[Tooltip("Enables a small, niche movement tech that has not been named.")]
@@ -52,7 +52,7 @@ namespace MetroidMod.Common.Configs
 		public bool spaceJumpRocketBoots;
 
 		[Label("[i:MetroidMod/HiJumpBootsAddon] Wall-Jump while in Morph Ball")]
-		[Tooltip("Once again will you be able to hop from wall to wall as a little ball.")]
+		[Tooltip("By default, you cannot Wall-Jump while in Morph Ball.\nIf this option is on, and you can Wall-Jump, then you will be able to do so while morphed.")]
 		[DefaultValue(false)]
 		public bool enableMorphBallWallJump;
 


### PR DESCRIPTION
The former description implied that Morph Ball grants Wall-Jump, which is not the case. This has been fixed.

Noved is to credit for the "Tech Preservation" title idea.