### PR TITLE
Vortex Augment, Shimmer & you

### DIFF
--- a/Common/Players/IgnoreShimmerModPlayer.cs
+++ b/Common/Players/IgnoreShimmerModPlayer.cs
@@ -1,0 +1,52 @@
+﻿using MonoMod.Cil;
+using Terraria;
+using Terraria.ModLoader;
+
+namespace MetroidMod.Common.Players
+{
+	/// <summary>
+	/// Patches the game to allow a player to move through shimmer with no speed loss
+	/// if the ignoreShimmer flag is active.
+	/// </summary>
+	public class IgnoreShimmerModPlayer : ModPlayer
+	{
+		/// <summary>
+		/// Whether the player should be able to move unhindered through shimmer.
+		/// </summary>
+		public bool ignoreShimmer;
+
+		public override void Load()
+		{
+			IL_Player.ShimmerCollision += (il) =>
+			{
+				float defaultSpeedMultiplier = 0.375f;
+
+				ILCursor c = new(il);
+
+				// Go to the instruction that loads the hardcoded shimmer speed multiplier
+				c.GotoNext(i => i.MatchLdcR4(defaultSpeedMultiplier));
+				c.Remove();
+
+				// Replace it with our own hardcoded shimmer speed multiplier
+				c.EmitLdarg0();
+				c.EmitDelegate((Player player) =>
+				{
+					if (player.TryGetModPlayer(out IgnoreShimmerModPlayer modPlayer))
+					{
+						if (modPlayer.ignoreShimmer)
+						{
+							return 1f;
+						}
+					}
+
+					return defaultSpeedMultiplier;
+				});
+			};
+		}
+
+		public override void ResetEffects()
+		{
+			ignoreShimmer = false;
+		}
+	}
+}

--- a/Content/SuitAddons/VortexAugment.cs
+++ b/Content/SuitAddons/VortexAugment.cs
@@ -28,22 +28,6 @@ namespace MetroidMod.Content.SuitAddons
 
 		public override void SetStaticDefaults()
 		{
-			// DisplayName.SetDefault("Vortex Augment");
-			/* Tooltip.SetDefault("+29 defense\n" +
-				"+55 overheat capacity\n" +
-				"15% decreased overheat use\n" +
-				"15% decreased Missile Charge Combo cost\n" +
-				"15% increased hunter damage\n" +
-				"13% increased hunter critical strike chance\n" +
-				"10% increased movement speed\n" +
-				"60% increased energy barrier efficiency\n" + // Provisional name
-				"37.5% increased energy barrier resilience\n" + // Provisional name
-				"Infinite breath underwater\n" +
-				"Immune to knockback\n" +
-				"Free movement in liquid\n" +
-				"Grants 14 seconds of lava immunity\n" +
-				"Default gravity in space\n" +
-				"Immune to Distorted and Amplified Gravity effects"); */
 			ItemID.Sets.ShimmerTransformToItem[ItemType] = SuitAddonLoader.GetAddon<NebulaAugment>().ItemType;
 			AddonSlot = SuitAddonSlotID.Suit_Primary;
 			ItemNameLiteral = true;
@@ -57,6 +41,12 @@ namespace MetroidMod.Content.SuitAddons
 		}
 		public override void OnUpdateArmorSet(Player player, int stack)
 		{
+			// Chromatic cloak ability
+			if (!player.controlDownHold)
+			{
+				player.shimmerImmune = true;
+			}
+
 			player.statDefense += 29;
 			player.noKnockback = true;
 			player.ignoreWater = true;

--- a/Content/SuitAddons/VortexAugment.cs
+++ b/Content/SuitAddons/VortexAugment.cs
@@ -1,9 +1,9 @@
-﻿using MetroidMod.Common.GlobalItems;
-using MetroidMod.Common.Players;
+﻿using MetroidMod.Common.Players;
 using MetroidMod.ID;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace MetroidMod.Content.SuitAddons
 {
@@ -45,6 +45,12 @@ namespace MetroidMod.Content.SuitAddons
 			if (!player.controlDownHold)
 			{
 				player.shimmerImmune = true;
+			}
+
+			// Ignore shimmer slowdown ability
+			if(player.TryGetModPlayer(out IgnoreShimmerModPlayer shimmerMp))
+			{
+				shimmerMp.ignoreShimmer = true;
 			}
 
 			player.statDefense += 29;

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -2811,7 +2811,9 @@ Mods: {
 					37.5% increased energy barrier resilience
 					Infinite breath underwater
 					Immune to knockback
-					Free movement in liquid
+					Free movement in liquids including shimmer
+					Immunity to Shimmer Phasing
+					Hold Down to Phase while submerged in Shimmer
 					Grants 14 seconds of lava immunity
 					Default gravity in space
 					Immune to Distorted and Amplified Gravity effects

--- a/Localization/es-ES.hjson
+++ b/Localization/es-ES.hjson
@@ -2811,7 +2811,9 @@ Mods: {
 					37.5% increased energy barrier resilience
 					Infinite breath underwater
 					Immune to knockback
-					Free movement in liquid
+					Free movement in liquids including shimmer
+					Immunity to Shimmer Phasing
+					Hold Down to Phase while submerged in Shimmer
 					Grants 14 seconds of lava immunity
 					Default gravity in space
 					Immune to Distorted and Amplified Gravity effects
@@ -3087,6 +3089,38 @@ Mods: {
 				// DisplayName: Crocomire Bone
 				// Tooltip: Summons a miniature pet Crocomire
 			}
+
+			/* BlueHatch.Tooltip:
+				'''
+				Right click to place vertically
+				Opens when hit with any projectile
+				Can also be opened with right click or when the bubble shield is wired
+				When the metal base is wired, can be locked when powered
+				''' */
+			/* GreenHatch.Tooltip:
+				'''
+				Right click to place vertically
+				Opens when hit with a Super Missile
+				Can also be opened with Green Keycard or when powered via bubble shield
+				Powering the metal bottom (or right when vertical) locks the hatch
+				You can use Chozite Wrench or power the top (or left when vertical) to toggle Bubble Shield mode
+				''' */
+			/* RedHatch.Tooltip:
+				'''
+				Right click to place vertically
+				Opens when hit a Missile
+				Can also be opened with Red Keycard or when powered via bubble shield
+				Powering the metal bottom (or right when vertical) locks the hatch
+				You can use Chozite Wrench or power the top (or left when vertical) to toggle Bubble Shield mode
+				''' */
+			/* YellowHatch.Tooltip:
+				'''
+				Right click to place vertically
+				Opens when hit with a Power Bomb
+				Can also be opened with Yellow Keycard or when powered via bubble shield
+				Powering the metal bottom (or right when vertical) locks the hatch
+				You can use Chozite Wrench or power the top (or left when vertical) to toggle Bubble Shield mode
+				''' */
 		}
 
 		NPCs: {


### PR DESCRIPTION
Gives the Vortex Augment a few handy abilities related to shimmer, which are:
- Prevent any speed loss from being submerged in shimmer
- Prevent phasing through it unless you press Down (identical to vanilla's Chromatic Cloak)