### PR TITLE
Fix missile combo arm cannon issue

### DIFF
--- a/Content/Items/Weapons/ArmCannon.cs
+++ b/Content/Items/Weapons/ArmCannon.cs
@@ -2464,10 +2464,6 @@ namespace MetroidMod.Content.Items.Weapons
 											}
 										}
 									}
-									else
-									{
-										Main.projectile[chargeLead].Kill();
-									}
 								}
 							}
 							else
@@ -2676,9 +2672,17 @@ namespace MetroidMod.Content.Items.Weapons
 						targetNum = 0;
 						targetingDelay = 0;
 					}
-					if(pb.statMissiles <= 0f && player.controlUseItem)
+
+					bool ranOutOfMissiles = pb.statMissiles <= 0f;
+					if (ranOutOfMissiles)
 					{
-						pb.isBeam = !pb.isBeam;
+						Main.projectile[chargeLead].Kill();
+
+						bool tryingToUseLauncher = Main.mouseLeft && Main.mouseLeftRelease;
+						if (tryingToUseLauncher)
+						{
+							pb.isBeam = true;
+						}
 					}
 				}
 


### PR DESCRIPTION
So basically you could be using a missile combo like Wavebuster, run out of missiles, and the player would keep holding the arm cannon, lead active and everything, but without firing anything. This PR fixes that, IIRC back to what is the now obsolete missile launcher behavior