### PR TITLE
Hunter Emblem Drop Fixes

### DIFF
--- a/Common/GlobalItems/MGlobalItem.cs
+++ b/Common/GlobalItems/MGlobalItem.cs
@@ -1,4 +1,5 @@
-﻿using MetroidMod.Common.Players;
+﻿using System.Linq;
+using MetroidMod.Common.Players;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
@@ -183,6 +184,17 @@ namespace MetroidMod.Common.GlobalItems
 				Lokidev.OnSuccess(ItemDropRule.Common(ModContent.ItemType<Content.Items.Vanity.Contributor.LokiDevItemLegs>(), 1));
 
 				itemLoot.Add(expertRule);
+			}
+
+			if (item.type == ItemID.WallOfFleshBossBag)
+			{
+				OneFromOptionsNotScaledWithLuckDropRule emblemDropRule = itemLoot.Get(includeGlobalDrops: false)
+					.OfType<OneFromOptionsNotScaledWithLuckDropRule>()
+					.FirstOrDefault(rule => rule.dropIds.Contains(ItemID.WarriorEmblem));
+				if (emblemDropRule != null)
+				{
+					emblemDropRule.dropIds = [.. emblemDropRule.dropIds.Append(ModContent.ItemType<Content.Items.Accessories.HunterEmblem>())];
+				}
 			}
 		}
 	}

--- a/Common/GlobalNPCs/MGlobalNPC.cs
+++ b/Common/GlobalNPCs/MGlobalNPC.cs
@@ -195,8 +195,18 @@ namespace MetroidMod.Common.GlobalNPCs
 
 			if (npc.type == NPCID.WallofFlesh)
 			{
-				npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<Content.Items.Accessories.HunterEmblem>()));
-				//Item.NewItem((int)npc.position.X, (int)npc.position.Y, npc.width, npc.height, mod.ItemType("HunterEmblem"), 1);
+				OneFromOptionsNotScaledWithLuckDropRule emblemDropRule = npcLoot.Get(includeGlobalDrops: false)
+					.OfType<LeadingConditionRule>()
+					.Where(rule => rule.condition is Conditions.NotExpert)
+					.SelectMany(rule => rule.ChainedRules)
+					.OfType<Chains.TryIfSucceeded>()
+					.Select(rule => rule.RuleToChain)
+					.OfType<OneFromOptionsNotScaledWithLuckDropRule>()
+					.FirstOrDefault(rule => rule.dropIds.Contains(ItemID.WarriorEmblem));
+				if (emblemDropRule != null)
+				{
+					emblemDropRule.dropIds = [.. emblemDropRule.dropIds.Append(ModContent.ItemType<Content.Items.Accessories.HunterEmblem>())];
+				}
 			}
 			if (npc.type == NPCID.IceQueen)
 			{


### PR DESCRIPTION
The Hunter Emblem now drops in the same pool as other class emblems (instead of dropping separately 100% of the time, regardless of difficulty). It also now correctly drops from the Wall of Flesh's Treasure Bag.