### PR TITLE
Fix for NullReferenceException when swapping helmets

### DIFF
--- a/Common/UI/SuitAddons/HelmetAddonsUI.cs
+++ b/Common/UI/SuitAddons/HelmetAddonsUI.cs
@@ -188,6 +188,7 @@ namespace MetroidMod.Common.UI.SuitAddons
 			// Item drawing.
 			if (Main.LocalPlayer.armor[0].IsAir) { return; }
 			PowerSuitHelmet helmet = Main.LocalPlayer.armor[0].ModItem as PowerSuitHelmet;
+			if (helmet is null) return;
 
 			Color itemColor = helmet.SuitAddons[addonSlotType - 4].GetAlpha(Color.White);
 			Texture2D itemTexture = TextureAssets.Item[helmet.SuitAddons[addonSlotType - 4].type].Value;


### PR DESCRIPTION
Noticed that a NRE was being thrown when swapping the helmet with the UI open. Occurs because the check for helmet drawing only tests for item ID 0, instead of checking if the item was a power suit or not.

## Steps to recreate
1. Equip a power suit helmet.
2. Remove the helmet by swapping to a non-air, non-powersuit helmet.